### PR TITLE
Added Android SDK validation (>= 21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ It brings up the [concept of elevation](https://material.io/guidelines/material-
 With this directive, you won't have to worry about all the aspects regarding shadowing on Android and on iOS.
 On the other hand, if you care about any details, just provide extra attributes and they will superseed the default ones.
 
+However, should you be running this on Android you will require the SDK to be greater or equal than 21 (Android 5.0 Lollipop or later), otherwise shadows will simply not be shown. There should be no problem running this on any version of iOS.
+
 #### Import the NgShadowModule
 ```typescript
 // ...

--- a/src/angular/ng-shadow.directive.ts
+++ b/src/angular/ng-shadow.directive.ts
@@ -114,6 +114,15 @@ export class NativeShadowDirective implements OnInit, OnChanges {
     ) {
       return;
     }
+
+    // For shadows to be shown on Android the SDK has to be greater
+    // or equal than 21, lower SDK means no setElevation method is available
+    if (isAndroid) {
+      if (android.os.Build.VERSION.SDK_INT < 21) {
+        return;
+      }
+    }
+
     const tnsView = this.el.nativeElement;
     if (tnsView.android) {
       this.applyOnAndroid(tnsView.android);


### PR DESCRIPTION
Hey!

So, as the title says, I added the validation for the Android SDK to have the setElevation method available and added a quick heads up to whoever reads the README that shadows are not shown on any version of Android older than Lollipop.

Since design didn't rely that much on shadows back then (as far as I can remember...) don't think it's a big deal, if it were I guess I could look for an alternative implementation that's compatible.

I tested my changes on Android 4.4 and made sure no unexpected behaviors were found by testing on Android 8.1 and iOS 11.2.

Hope you find this useful!