### PR TITLE
Adding NGC compiler support for AOT and Web pack compatibility. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.js.map
 *.log
 src/*.d.ts
+src/**/*metadata.json
 !src/index.d.ts
 !src/references.d.ts
 !src/scripts/*.js

--- a/publish/pack.sh
+++ b/publish/pack.sh
@@ -28,7 +28,8 @@ pack() {
     # compile package and copy files required by npm
     echo 'Building /src...'
     cd "$TO_SOURCE_DIR"
-    node_modules/.bin/tsc
+    # compile project with ngc compiler
+    npm run ngc
     cd ..
 
     echo 'Creating package...'

--- a/src/package.json
+++ b/src/package.json
@@ -71,7 +71,9 @@
         "tns-core-modules": "^3.1.0",
         "tns-platform-declarations": "^3.1.0",
         "tslint": "^5.0.0",
-        "typescript": "~2.4.0"
+        "typescript": "~2.4.0",
+        "@angular/compiler": "~4.2.5",
+        "@angular/compiler-cli": "~4.2.5"
     },
     "dependencies": {},
     "bootstrapper": "nativescript-plugin-seed"

--- a/src/package.json
+++ b/src/package.json
@@ -26,7 +26,8 @@
         "demo.reset": "cd ../demo && rimraf platforms",
         "plugin.prepare": "npm run tsc && cd ../demo && tns plugin remove nativescript-ng-shadow && tns plugin add ../src",
         "clean": "cd ../demo && rimraf hooks node_modules platforms && cd ../src && rimraf node_modules && npm run plugin.link",
-        "ci.tslint": "npm i && tslint '**/*.ts' --config '../tslint.json' --exclude '**/node_modules/**' --exclude '**/tns_modules/**' --exclude '**/*.d.ts'"
+        "ci.tslint": "npm i && tslint '**/*.ts' --config '../tslint.json' --exclude '**/node_modules/**' --exclude '**/tns_modules/**' --exclude '**/*.d.ts'",
+        "ngc": "./node_modules/.bin/ngc --p tsconfig.ngc.json"
     },
     "keywords": [
         "NativeScript",
@@ -72,7 +73,6 @@
         "tns-platform-declarations": "^3.1.0",
         "tslint": "^5.0.0",
         "typescript": "~2.4.0",
-        "@angular/compiler": "~4.2.5",
         "@angular/compiler-cli": "~4.2.5"
     },
     "dependencies": {},

--- a/src/tsconfig.ngc.json
+++ b/src/tsconfig.ngc.json
@@ -1,0 +1,38 @@
+{
+	"compilerOptions": {
+		"baseUrl": "./",
+		"outDir": "./",
+		"sourceMap": false,
+		"declaration": true,
+		"moduleResolution": "node",
+		"emitDecoratorMetadata": true,
+		"experimentalDecorators": true,
+		"target": "es5",
+		"typeRoots": [
+			"node_modules/@types"
+		],
+		"lib": [
+			"es2017",
+			"dom"
+		],
+		"paths": {
+			"@angular/*": [
+				"./node_modules/@angular/*"
+            ],
+            "tns-core-modules":[
+                "./node_modules/tns-core-modules/*"
+            ]
+		}
+	},
+	"angularCompilerOptions": {
+		"skipTemplateCodegen": true
+	},
+	"include": [
+		"./"
+	],
+	"exclude": [
+		"**/**.spec.ts",
+        "**/platforms/*",
+        "**/node_modules/*"
+	]
+}


### PR DESCRIPTION
@especializa-user  and @berardo  thank you so much for this wonderful Angular Directive. I've taken the liberty to upgrade the project to compile using Angular NGC compiler instead of typescripts compiler. This should be enough to allow webpack and AOT compatibility. However, I'm not familiar with your build scripts so it's quite possible I missed something.  This should help resolve these issues:
 https://github.com/Especializa/nativescript-ng-shadow/issues/6 